### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/template-eu-west-1.yaml
+++ b/template-eu-west-1.yaml
@@ -34,7 +34,7 @@ Parameters:
   BotCodeRuntime:
     Type: String
     Default: python2.7
-    AllowedValues: [nodejs, nodejs4.3, nodejs6.10, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
+    AllowedValues: [nodejs, nodejs4.3, nodejs10.x, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
   BotCodeHandler:
     Type: String
     Default: process_stream.lambda_handler

--- a/template-us-east-1.yaml
+++ b/template-us-east-1.yaml
@@ -34,7 +34,7 @@ Parameters:
   BotCodeRuntime:
     Type: String
     Default: python2.7
-    AllowedValues: [nodejs, nodejs4.3, nodejs6.10, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
+    AllowedValues: [nodejs, nodejs4.3, nodejs10.x, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
   BotCodeHandler:
     Type: String
     Default: process_stream.lambda_handler

--- a/template-us-west-2.yaml
+++ b/template-us-west-2.yaml
@@ -34,7 +34,7 @@ Parameters:
   BotCodeRuntime:
     Type: String
     Default: python2.7
-    AllowedValues: [nodejs, nodejs4.3, nodejs6.10, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
+    AllowedValues: [nodejs, nodejs4.3, nodejs10.x, java8, python2.7, python3.6, dotnetcore1.0, nodejs4.3-edge]
   BotCodeHandler:
     Type: String
     Default: process_stream.lambda_handler


### PR DESCRIPTION
CloudFormation templates in aws-rekognition-workshop-twitter-bot have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.